### PR TITLE
Remove invalid char in preset reference

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    'github>cert-manager/renovate-config:default.json5̈́',
+    'github>cert-manager/renovate-config:default.json5',
   ],
 }


### PR DESCRIPTION
No idea how this happened, but Renovate doesn't like it. Even if the validator says it's OK, both before and after.

/cc @ThatsMrTalbot @hjoshi123 
/approve