### PR TITLE
Make renovate/renovate dependency require approval

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -100,6 +100,12 @@
       dependencyDashboardApproval: true
     },
     {
+      matchPackageNames: [
+        'renovate/renovate',
+      ],
+      dependencyDashboardApproval: true,
+    },
+    {
       description: 'Disable (internal) cert-manager pseudo-version updates',
       matchManagers: [
         'gomod',


### PR DESCRIPTION
As Renovate is released "all the time" (several times per day), I suggest requiring dependency dashboard approval for this dependency. As we probably want this to be the case across our projects, I'm adding it to the preset config, which is also used here.

Ref. https://github.com/cert-manager/renovate-config/pull/8

/cc @hjoshi123 
/approve