### PR TITLE
General preset improvements

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -6,9 +6,11 @@
   ],
   extends: [
     'config:best-practices',
+    'customManagers:githubActionsVersions',
     ':gitSignOff',
     ':semanticCommits',
     ':disableVulnerabilityAlerts',
+    ':disableRateLimiting',
   ],
   timezone: 'Europe/London',
   // packageRules uses globs for matchPackageNames. Some packages have a separate major version i.e. /v on them which is when we would need package**/**.
@@ -98,6 +100,14 @@
         'digest',
       ],
       dependencyDashboardApproval: true
+    },
+    {
+      matchManagers: [
+        'gomod',
+      ],
+      postUpdateOptions: [
+        'gomodTidy',
+      ],
     },
     {
       matchPackageNames: [


### PR DESCRIPTION
After some initial testing of this new preset, I propose some first-step improvements:

- Disable rate limiting, since we generally allow merge commits into the default branch.
- Add the [customManagers:githubActionsVersions](https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions) preset. This could be used to renovate versions like https://github.com/cert-manager/sample-external-issuer/blob/main/.github/workflows/lint.yml#L23.
- Enabling `go mod tidy` as a [postUpgrade](https://docs.renovatebot.com/configuration-options/#postupdateoptions) option. We may need to use the custom targets in makefile-modules to accomplish this, at least in some projects. But I want to keep the preset independent of makefile-modules if possible.