### PR TITLE
Force dependencyDashboardApproval for renovate/renovate

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -110,6 +110,9 @@
       ],
     },
     {
+      matchDatasources: [
+        'docker',
+      ],
       matchPackageNames: [
         'renovate/renovate',
       ],


### PR DESCRIPTION
With the current configuration, https://github.com/cert-manager/renovate-config/pull/13 should require a dependency dashboard approval. But somehow this is not working. Same issue in https://github.com/cert-manager/makefile-modules/pull/429.

I'm trying to make the package rule even more precise to see if it works.