### PR TITLE
Add default labels to PRs

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -13,6 +13,10 @@
     ':disableRateLimiting',
   ],
   timezone: 'Europe/London',
+  labels: [
+    'dependencies',
+    'ok-to-test',
+  ],
   // packageRules uses globs for matchPackageNames. Some packages have a separate major version i.e. /v on them which is when we would need package**/**.
   packageRules: [
     {


### PR DESCRIPTION
This PR configures Renovate to add some commonly used labels in our projects. I know cert-manager probably needs more labels to work 100%, but since this has become a preset now, we can configure the additional labels required in cert-manager locally.

See examples of "stuck" PRs here: https://github.com/cert-manager/trust-manager-csi-driver/pulls

/cc @hjoshi123 @ThatsMrTalbot 