### PR TITLE
Run 'make generate-helm-docs' when Helm values file updated

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -122,6 +122,17 @@
       dependencyDashboardApproval: true,
     },
     {
+      matchFileNames: [
+        'deploy/charts/**/values.yaml',
+      ],
+      postUpgradeTasks: {
+        commands: [
+          'make generate-helm-docs',
+        ],
+        executionMode: 'branch',
+      },
+    },
+    {
       description: 'Disable (internal) cert-manager pseudo-version updates',
       matchManagers: [
         'gomod',


### PR DESCRIPTION
To ensure Helm docs are updated. Example PR that should be fixed by this: https://github.com/cert-manager/trust-manager-csi-driver/pull/31.

I am proposing simple file matching patterns here to keep things simple in this shared preset.

/cc @hjoshi123 @ThatsMrTalbot 