### PR TITLE
Fix 'make vendor-go' appears required to generate Helm docs

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -127,7 +127,7 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'make generate-helm-docs',
+          'make vendor-go generate-helm-docs',
         ],
         executionMode: 'branch',
       },


### PR DESCRIPTION
No idea why this is required; it might be a bug in makefile-modules, but it appears like `make vendor-go` is required to generate Helm docs. See https://github.com/cert-manager/trust-manager-csi-driver/pull/31#issuecomment-3288627886

/cc @hjoshi123 @ThatsMrTalbot @inteon 