### PR TITLE
Just run 'make generate' to keep things simple

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -127,7 +127,7 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'make vendor-go generate-helm-docs',
+          'make vendor-go generate',
         ],
         executionMode: 'branch',
       },


### PR DESCRIPTION
It seems like the Helm schema must be generated as well, so https://github.com/cert-manager/renovate-config/pull/17 is not enough. I suggest just using the generic (but slow) `make generate` for now.

/cc @hjoshi123 @ThatsMrTalbot 