### PR TITLE
Run 'make generate' on all go.mod updates

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -106,14 +106,6 @@
       dependencyDashboardApproval: true
     },
     {
-      matchManagers: [
-        'gomod',
-      ],
-      postUpdateOptions: [
-        'gomodTidy',
-      ],
-    },
-    {
       // Set groupName to null to avoid this dependency from being included in the misc GHA group above.
       groupName: null,
       matchPackageNames: [
@@ -123,6 +115,7 @@
     },
     {
       matchFileNames: [
+        '**/go.mod', // This will break all projects using this preset, but not makefile-module.
         'deploy/charts/**/values.yaml',
       ],
       postUpgradeTasks: {


### PR DESCRIPTION
The Renovate `gomodTidy` post update option is not enough for dealing with multi-module Go projects. Example failing PR: https://github.com/cert-manager/csi-lib/pull/114.

I wish multi-module projects were better supported in Go, and not "bolted on", as it appears to be now.

Ref. the comment I added, I would prefer to avoid tying this even more to makefile-modules, as it will make the preset unusable in projects not using makefile-modules. https://github.com/cert-manager/sample-external-issuer is such an example. I think the workaround will be to just not use this preset when makefile-modules is not enabled on the project.

Also, the currently required `make go-vendor` makes the Renovate run really heavy/slow. But I don't know if it can be avoided?