### PR TITLE
add a 3 day minimum release age by default

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -13,6 +13,7 @@
     'mergeConfidence:all-badges',
   ],
   timezone: 'Europe/London',
+  minimumReleaseAge: '3 days',
   labels: [
     'dependencies',
     'ok-to-test',


### PR DESCRIPTION
This helps protect against the acute effects of a compromised dependency publishing a malicious release of some kind