### PR TITLE
Unset minimumReleaseAge for c-m packages

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -118,6 +118,12 @@
       dependencyDashboardApproval: true,
     },
     {
+      description: 'Disable minimum release age and auto-merge for selective dependencies',
+      matchPackageNames: ['github.com/cert-manager/**'],
+      minimumReleaseAge: null,
+      addLabels: ['skip-review'], // Adding label to allow PRs to automerge
+    },
+    {
       groupName: null,
       description: 'Disable (internal) cert-manager pseudo-version updates',
       matchManagers: ['gomod'],


### PR DESCRIPTION
I think we can allow internal cert-manager dependencies to merge ASAP. Example: https://github.com/cert-manager/issuer-lib/pull/471

Also, allow c-m upgrade PRs to auto-merge.