### PR TITLE
Set statusCheckWhen.minimumReleaseAge to never

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -14,6 +14,9 @@
   ],
   timezone: 'Europe/London',
   minimumReleaseAge: '3 days',
+  statusCheckWhen: {
+    minimumReleaseAge: 'never', // To avoid blocking renovate/stability-days GH workflows.
+  },
   labels: [
     'dependencies',
     'ok-to-test',


### PR DESCRIPTION
To avoid Renovate creating blocking GH workflows like the one observed in https://github.com/cert-manager/cert-manager/pull/8954.

<img width="1080" height="289" alt="image" src="https://github.com/user-attachments/assets/29e420e3-0499-4ab5-af4f-27768d88a885" />

If these PRs are approved, Prow will be blocked for the project, as we have been observing stale "changes requested".

Docs: https://docs.renovatebot.com/configuration-options/#statuscheckwhen