### PR TITLE
Enable go.mod indirect security updates

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -9,7 +9,7 @@
     'customManagers:githubActionsVersions',
     ':gitSignOff',
     ':semanticCommits',
-    ':enableVulnerabilityAlerts',
+    'security:gomodIndirectSecurityUpdates',
     'mergeConfidence:all-badges',
   ],
   timezone: 'Europe/London',


### PR DESCRIPTION
I have noticed that we usually get PRs from Dependabot when there is a vulnerability in indirect go.mod dependencies. This change should make Renovate catch them, avoiding the need to rely on two dependency tools. Ref. https://docs.renovatebot.com/presets-security/#securitygomodindirectsecurityupdates. Note that this appears to be an extension of the current config, so what was working before should still work.