### PR TITLE
Unset gitAuthor so Renovate discovers its real commit identity

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -1,9 +1,9 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  // Must match the author the Renovate GitHub App actually commits with,
-  // otherwise Renovate mistakes its own stale branches for manually edited
-  // ones and blocks them ("PR Edited (Blocked)" on the dependency dashboard).
-  gitAuthor: 'renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>',
+  // gitAuthor is deliberately unset so Renovate discovers its own commit
+  // identity from its platform credentials. A hard-coded value that does not
+  // match the app's real identity makes Renovate mistake its own branches for
+  // manually edited ones ("PR Edited (Blocked)" on the dependency dashboard).
   gitIgnoredAuthors: [
     '157150467+octo-sts[bot]@users.noreply.github.com',
   ],

--- a/default.json5
+++ b/default.json5
@@ -1,6 +1,9 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  gitAuthor: 'Renovate Bot <renovate-bot@users.noreply.github.com>',
+  // Must match the author the Renovate GitHub App actually commits with,
+  // otherwise Renovate mistakes its own stale branches for manually edited
+  // ones and blocks them ("PR Edited (Blocked)" on the dependency dashboard).
+  gitAuthor: 'renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>',
   gitIgnoredAuthors: [
     '157150467+octo-sts[bot]@users.noreply.github.com',
   ],


### PR DESCRIPTION
Fixes the "PR Edited (Blocked)" entries on the cert-manager Dependency Dashboard (cert-manager/cert-manager#8309), which have frozen the "Misc Go deps" and "Misc GitHub actions" groups since 2026-05-28 and are the reason expected updates (e.g. go-ldap) never arrived.

## Cause

The configured `gitAuthor` (`Renovate Bot <renovate-bot@users.noreply.github.com>`) does not match the identity the Renovate GitHub App actually commits with (`renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>`). Renovate's `isBranchModified` check compares every author/committer email on the branch against `gitAuthorEmail` and `gitIgnoredAuthors`; any mismatch marks the branch as manually edited and Renovate stops touching it:
https://github.com/renovatebot/renovate/blob/44.27.0/lib/util/git/index.ts#L1007-L1018

So Renovate treats its own stale branches as edited by a human.

## Fix

Unset `gitAuthor` entirely, as the docs recommend:

> You can customize the Git author that's used whenever Renovate creates a commit, although we do not recommend this. When this field is unset (default), Renovate will use its platform credentials (e.g. token) to learn/discover its account's git author automatically.
> — https://docs.renovatebot.com/configuration-options/#gitauthor

Discovery constructs exactly the app's real identity, `<name> <<id>+<username>@users.noreply.github.com>`:
https://github.com/renovatebot/renovate/blob/44.27.0/lib/modules/platform/github/index.ts#L224-L249

The `:gitSignOff` preset keeps working: `initPlatform` returns the discovered author into the config, so its `Signed-off-by: {{{gitAuthor}}}` template still resolves.

## History

The field dates from the self-hosted Renovate era: cert-manager/makefile-modules#383 introduced `gitAuthor` (then `cert-manager-bot`) so Renovate's PRs could be distinguished, and this repo's initial setup (4617728, 2025-09-06) carried `Renovate Bot <renovate-bot@users.noreply.github.com>` over. Since the switch to the hosted Mend app, which commits as `renovate[bot]`, the hard-coded value has pointed at an identity that no longer makes the commits.

## Prior art

cert-manager/makefile-modules#399 hit the same symptom and worked around it with `gitIgnoredAuthors` plus `recreateWhen: 'always'` (marked as a temporary fix). Note that those `gitIgnoredAuthors` entries are `Name <email>` strings, but Renovate compares them against bare commit emails with no normalisation (https://github.com/renovatebot/renovate/blob/44.27.0/lib/util/git/index.ts#L404-L410), so `recreateWhen` is likely what actually papered over it there. Once this lands, makefile-modules' own `.github/renovate.json5` can drop its hard-coded `gitAuthor` and those workarounds.

## After-merge expectations

The gitAuthor mismatch is also why stale `renovate/*` branches have accumulated: `pruneStaleBranches` (on by default) deletes orphaned branches each run, but skips any branch `isBranchModified` flags as human-edited (https://github.com/renovatebot/renovate/blob/44.27.0/lib/workers/repository/finalize/prune.ts#L92-L96), and the mismatch flagged every branch. Taking cert-manager/cert-manager as the example:

**Cleaned up automatically** — `renovate/master-cloud-go-deps`, the two `master-go-go.opentelemetry.io-*-vulnerability` branches, and the eight `release-1.20-*` branches. Their heads are authored by `renovate[bot]` and prune can resolve their base branch (master and release-1.20 are in `baseBranchPatterns`), so they will be deleted — or recreated with a fresh PR where the update is still pending (misc-go-deps, misc-github-actions, cloud-go-deps).

**Caveat** — `isBranchModified` verdicts are cached per branch SHA (https://github.com/renovatebot/renovate/blob/44.27.0/lib/util/git/modified-cache.ts#L13-L15), so a branch whose SHA has not changed can keep its stale "modified" verdict after this fix. Hence:

- [ ] Tick the two "discard commits and start over" checkboxes on cert-manager/cert-manager#8309 so the stale `renovate/master-misc-go-deps` and `renovate/master-misc-github-actions` branches are recreated.

**Needs manual deletion** — the four `release-1.19-*` branches: release-1.19 is no longer in `baseBranchPatterns`, so prune's base-branch regex (https://github.com/renovatebot/renovate/blob/44.27.0/lib/workers/repository/finalize/prune.ts#L127-L146) falls back to master, the `master..branch` range then contains all of release-1.19's human-authored history, and they test as "modified" forever. Likewise `renovate/reconfigure`, which is explicitly excluded from pruning (https://github.com/renovatebot/renovate/blob/44.27.0/lib/workers/repository/finalize/prune.ts#L166-L168).

- [ ] `git push upstream --delete renovate/release-1.19-{github.com-go-ldap-ldap-v3-3.x,makefile-modules,misc-github-actions,misc-go-deps} renovate/reconfigure`

Enabling GitHub's "automatically delete head branches" on the repos would stop merged-PR branches accumulating regardless of Renovate's pruning.

*with claude fable-5*
