### PR TITLE
Exempt go dependency from the minumum release age

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -129,6 +129,11 @@
       addLabels: ['skip-review'], // Adding label to allow PRs to automerge
     },
     {
+      description: 'Disable minimum release age for Go upgrades',
+      matchDatasources: ['golang-version'],
+      minimumReleaseAge: null,
+    },
+    {
       description: 'Disable minimum release age and enable auto-merge for selective dependencies',
       matchPackageNames: ['github.com/cert-manager/**'],
       minimumReleaseAge: null,


### PR DESCRIPTION
There is currently a new version of Go fixing some vulnerabilities. The Go maintainers are trusted, and we would like to disable the default minimum release age ~(and auto-merge~) for this dependency.